### PR TITLE
Avro Schema exposure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ val flinkDependencies = Seq(
 
 val coreDependencies = Seq(
   // "codes.reactive" %% "scala-time" % "0.4.1",
-  // "org.apache.zookeeper" % "zookeeper" % "3.4.9",
+  "org.apache.zookeeper" % "zookeeper" % "3.4.9",
   // "org.mockito" % "mockito-core" % "2.13.0" % "test",
   "org.json4s" % "json4s-scalap_2.11" % "3.6.0-M2",
   "org.json4s" % "json4s-jackson_2.11" % "3.6.0-M2",

--- a/src/main/scala/org/codefeedr/pipeline/buffer/Exceptions.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/Exceptions.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.codefeedr.pipeline.buffer
+
+final case class SchemaNotFoundException(private val message: String = "",
+                                        private val cause: Throwable = None.orNull)
+  extends Exception(message, cause)
+
+final case class NoAvroSerdeException(private val message: String = "",
+                                         private val cause: Throwable = None.orNull)
+  extends Exception(message, cause)
+

--- a/src/main/scala/org/codefeedr/pipeline/buffer/KafkaBuffer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/KafkaBuffer.scala
@@ -50,17 +50,19 @@ object KafkaBuffer {
   val SCHEMA_EXPOSURE = "SCHEMA_EXPOSURE"
   val SCHEMA_EXPOSURE_SERVICE = "SCHEMA_EXPOSURE_SERVICE"
   val SCHEMA_EXPOSURE_HOST = "SCHEMA_EXPOSURE_HOST"
+}
 
+private object KafkaBufferDefaults {
   /**
     * DEFAULT VALUES
     */
-  val DEFAULT_BROKER = "localhost:9092"
-  val DEFAULT_ZOOKEEPER = "localhost:2181"
+  val BROKER = "localhost:9092"
+  val ZOOKEEPER = "localhost:2181"
 
   //SCHEMA EXPOSURE
-  val DEFAULT_SCHEMA_EXPOSURE = false
-  val DEFAULT_SCHEMA_EXPOSURE_SERVICE = "redis"
-  val DEFAULT_SCHEMA_EXPOSURE_HOST = "redis://localhost:6379"
+  val SCHEMA_EXPOSURE = false
+  val SCHEMA_EXPOSURE_SERVICE = "redis"
+  val SCHEMA_EXPOSURE_HOST = "redis://localhost:6379"
 }
 
 class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic: String) extends Buffer[T](pipeline) {
@@ -80,7 +82,7 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
     
     //make sure the topic already exists
     checkAndCreateSubject(topic, props.get[String](KafkaBuffer.BROKER).
-      getOrElse(KafkaBuffer.DEFAULT_BROKER))
+      getOrElse(KafkaBufferDefaults.BROKER))
 
     pipeline.environment.
       addSource(new FlinkKafkaConsumer011[T](topic, serde, getKafkaProperties()))
@@ -94,7 +96,7 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
 
     //check if a schema should be exposed
     if (props.get[Boolean](KafkaBuffer.SCHEMA_EXPOSURE)
-      .getOrElse(KafkaBuffer.DEFAULT_SCHEMA_EXPOSURE)) {
+      .getOrElse(KafkaBufferDefaults.SCHEMA_EXPOSURE)) {
       exposeSchema()
     }
 
@@ -110,9 +112,9 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
 
     val kafkaProp = new java.util.Properties()
     kafkaProp.put("bootstrap.servers", props.get[String](KafkaBuffer.BROKER).
-      getOrElse(KafkaBuffer.DEFAULT_BROKER))
+      getOrElse(KafkaBufferDefaults.BROKER))
     kafkaProp.put("zookeeper.connect", props.get[String](KafkaBuffer.ZOOKEEPER).
-      getOrElse(KafkaBuffer.DEFAULT_ZOOKEEPER))
+      getOrElse(KafkaBufferDefaults.ZOOKEEPER))
     kafkaProp.put("auto.offset.reset", "earliest")
     kafkaProp.put("auto.commit.interval.ms", "100")
     kafkaProp.put("enable.auto.commit", "true")
@@ -161,11 +163,11 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
 
     val exposeName = props.
       get[String](KafkaBuffer.SCHEMA_EXPOSURE_SERVICE).
-      getOrElse(KafkaBuffer.DEFAULT_SCHEMA_EXPOSURE_SERVICE)
+      getOrElse(KafkaBufferDefaults.SCHEMA_EXPOSURE_SERVICE)
 
     val exposeHost = props.
       get[String](KafkaBuffer.SCHEMA_EXPOSURE_HOST).
-      getOrElse(KafkaBuffer.DEFAULT_SCHEMA_EXPOSURE_HOST)
+      getOrElse(KafkaBufferDefaults.SCHEMA_EXPOSURE_HOST)
 
     //get exposer
     val exposer = exposeName match {

--- a/src/main/scala/org/codefeedr/pipeline/buffer/KafkaBuffer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/KafkaBuffer.scala
@@ -21,6 +21,9 @@ package org.codefeedr.pipeline.buffer
 import java.util.Properties
 
 import com.sksamuel.avro4s.{FromRecord, SchemaFor}
+import org.apache.avro.Schema
+import org.apache.avro.reflect.ReflectData
+import org.codefeedr.Properties._
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.connectors.kafka.{FlinkKafkaConsumer011, FlinkKafkaProducer011}
 import org.codefeedr.pipeline.buffer.serialization._
@@ -30,18 +33,34 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, KafkaAdminClient, NewTopic}
 import org.codefeedr.pipeline.Pipeline
+import org.codefeedr.pipeline.buffer.serialization.schema_exposure.{RedisSchemaExposer, ZookeeperSchemaExposer}
 
 import scala.collection.JavaConverters._
-
 import scala.reflect.Manifest
 
 object KafkaBuffer {
+  /**
+    * PROPERTIES
+    */
   val BROKER = "HOST"
   val ZOOKEEPER = "ZOOKEEPER"
   val SERIALIZER = "SERIALIZER"
 
+  //SCHEMA EXPOSURE
+  val SCHEMA_EXPOSURE = "SCHEMA_EXPOSURE"
+  val SCHEMA_EXPOSURE_SERVICE = "SCHEMA_EXPOSURE_SERVICE"
+  val SCHEMA_EXPOSURE_HOST = "SCHEMA_EXPOSURE_HOST"
+
+  /**
+    * DEFAULT VALUES
+    */
   val DEFAULT_BROKER = "localhost:9092"
   val DEFAULT_ZOOKEEPER = "localhost:2181"
+
+  //SCHEMA EXPOSURE
+  val DEFAULT_SCHEMA_EXPOSURE = false
+  val DEFAULT_SCHEMA_EXPOSURE_SERVICE = "redis"
+  val DEFAULT_SCHEMA_EXPOSURE_HOST = "redis://localhost:6379"
 }
 
 class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic: String) extends Buffer[T](pipeline) {
@@ -55,26 +74,16 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
   override def getSource: DataStream[T] = {
     val props = pipeline.bufferProperties
 
-    //TODO make this configurable
-    val kafkaProp = new java.util.Properties()
-    val broker = props.get[String](KafkaBuffer.BROKER).
-      getOrElse(KafkaBuffer.DEFAULT_BROKER)
-    kafkaProp.put("bootstrap.servers", broker)
-    kafkaProp.put("zookeeper.connect", props.get[String](KafkaBuffer.ZOOKEEPER).
-      getOrElse(KafkaBuffer.DEFAULT_ZOOKEEPER))
-    kafkaProp.put("auto.offset.reset", "earliest")
-    kafkaProp.put("auto.commit.interval.ms", "100")
-    kafkaProp.put("enable.auto.commit", "true")
-
     val serde = Serializer.
       getSerde[T](props.get[String](KafkaBuffer.SERIALIZER).
       getOrElse(Serializer.JSON))
     
     //make sure the topic already exists
-    checkAndCreateSubject(topic, broker)
+    checkAndCreateSubject(topic, props.get[String](KafkaBuffer.BROKER).
+      getOrElse(KafkaBuffer.DEFAULT_BROKER))
 
     pipeline.environment.
-      addSource(new FlinkKafkaConsumer011[T](topic, serde, kafkaProp))
+      addSource(new FlinkKafkaConsumer011[T](topic, serde, getKafkaProperties()))
   }
 
   override def getSink: SinkFunction[T] = {
@@ -82,6 +91,22 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
 
     val serde = Serializer.getSerde[T](props.get[String](KafkaBuffer.SERIALIZER).
       getOrElse(Serializer.JSON))
+
+    //check if a schema should be exposed
+    if (props.get[Boolean](KafkaBuffer.SCHEMA_EXPOSURE)
+      .getOrElse(KafkaBuffer.DEFAULT_SCHEMA_EXPOSURE)) {
+      exposeSchema()
+    }
+
+    new FlinkKafkaProducer011[T](topic, serde, getKafkaProperties())
+  }
+
+  /**
+    * Get all the kafka properties.
+    * @return a map with all the properties.
+    */
+  def getKafkaProperties() : java.util.Properties = {
+    val props = pipeline.bufferProperties
 
     val kafkaProp = new java.util.Properties()
     kafkaProp.put("bootstrap.servers", props.get[String](KafkaBuffer.BROKER).
@@ -92,7 +117,7 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
     kafkaProp.put("auto.commit.interval.ms", "100")
     kafkaProp.put("enable.auto.commit", "true")
 
-    new FlinkKafkaProducer011[T](topic, serde, kafkaProp)
+    kafkaProp
   }
 
   /**
@@ -126,5 +151,33 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
         .all()
         .get() //this blocks the method until the topic is created
     }
+  }
+
+  /**
+    * Exposes the Avro schema to an external service (like redis/zookeeper).
+    */
+  def exposeSchema() = {
+    val props = pipeline.bufferProperties
+
+    val exposeName = props.
+      get[String](KafkaBuffer.SCHEMA_EXPOSURE_SERVICE).
+      getOrElse(KafkaBuffer.DEFAULT_SCHEMA_EXPOSURE_SERVICE)
+
+    val exposeHost = props.
+      get[String](KafkaBuffer.SCHEMA_EXPOSURE_HOST).
+      getOrElse(KafkaBuffer.DEFAULT_SCHEMA_EXPOSURE_HOST)
+
+    //get exposer
+    val exposer = exposeName match {
+      case "redis" => new RedisSchemaExposer(exposeHost)
+      case "zookeeper" => new ZookeeperSchemaExposer(exposeHost)
+      case _ => new RedisSchemaExposer(exposeHost) //default is redis
+    }
+
+    //get the schema
+    val schema = ReflectData.get().getSchema(inputClassType)
+
+    //expose the schema
+    exposer.putSchema(schema, topic)
   }
 }

--- a/src/main/scala/org/codefeedr/pipeline/buffer/KafkaBuffer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/KafkaBuffer.scala
@@ -169,7 +169,6 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
 
     //get exposer
     val exposer = exposeName match {
-      case "redis" => new RedisSchemaExposer(exposeHost)
       case "zookeeper" => new ZookeeperSchemaExposer(exposeHost)
       case _ => new RedisSchemaExposer(exposeHost) //default is redis
     }

--- a/src/main/scala/org/codefeedr/pipeline/buffer/KafkaBuffer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/KafkaBuffer.scala
@@ -185,7 +185,7 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
     val schema = ReflectData.get().getSchema(inputClassType)
 
     //expose the schema
-    exposer.putSchema(schema, topic)
+    exposer.put(schema, topic)
   }
 
   /**
@@ -196,7 +196,7 @@ class KafkaBuffer[T <: AnyRef : Manifest : FromRecord](pipeline: Pipeline, topic
     val exposer = getExposer()
 
     //get the schema corresponding to the topic
-    val schema = exposer.getSchema(subject)
+    val schema = exposer.get(subject)
 
     //if not found throw exception
     if (schema.isEmpty) throw new SchemaNotFoundException(s"Schema for topic $topic not found.")

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/AvroSerde.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/AvroSerde.scala
@@ -59,7 +59,7 @@ class AvroSerde[T: ClassTag](limit : Int = -1)(implicit val recordFrom: FromReco
     * @return a deserialized case class.
     */
   override def deserialize(message: Array[Byte]): T = {
-    val schema: Schema = ReflectData.get().getSchema(inputClassType);
+    val schema: Schema = ReflectData.get().getSchema(inputClassType)
     val datumReader = new GenericDatumReader[GenericRecord](schema)
     val decoder = DecoderFactory.get().binaryDecoder(message, null)
 

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/RedisSchemaExposer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/RedisSchemaExposer.scala
@@ -51,7 +51,7 @@ class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") exten
     * @param subject the subject belonging to that schema.
     * @return true if correctly saved
     */
-  override def putSchema(schema: Schema, subject: String): Boolean = {
+  override def put(schema: Schema, subject: String): Boolean = {
     connection.set(s"$root:$subject", schema.toString(true))
   }
 
@@ -61,14 +61,14 @@ class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") exten
     * @param subject the subject the schema belongs to.
     * @return None if no schema is found or an invalid schema. Otherwise it returns the schema.
     */
-  override def getSchema(subject: String): Option[Schema] = {
+  override def get(subject: String): Option[Schema] = {
     val schemaString = connection.get[String](s"$root:$subject")
 
     //if no string is found, return None
     if (schemaString.isEmpty) return None
 
     //parse the string into a Schema
-    parseSchema(schemaString.get)
+    parse(schemaString.get)
   }
 
 
@@ -78,7 +78,7 @@ class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") exten
     * @param subject the subject the schema belongs to.
     * @return true if successfully deleted, otherwise false.
     */
-  override def delSchema(subject: String): Boolean = {
+  override def delete(subject: String): Boolean = {
     val deleted = connection.del(s"$root:$subject")
 
     //if deleted doesnt return anything or less than 1 key is deleted, return false
@@ -92,7 +92,7 @@ class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") exten
   /**
     * Deletes all schemas 'under' the root.
     */
-  override def deleteAllSchemas() = {
+  override def deleteAll() = {
     val keys = connection.keys(s"[$root]*")
 
     if (!keys.isEmpty) {

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/RedisSchemaExposer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/RedisSchemaExposer.scala
@@ -23,6 +23,12 @@ import java.net.URI
 import com.redis.RedisClient
 import org.apache.avro.Schema
 
+/**
+  * Exposes (Avro) schema's to Redis.
+  * @param host the server host of Redis.
+  * @param root the root location of the schema's
+  *             DEFAULT: /codefeedr:schemas
+  */
 class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") extends SchemaExposer {
 
   private var connection: RedisClient = _
@@ -31,7 +37,7 @@ class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") exten
   connect()
 
   /**
-    * Connect with the RedisClien.t
+    * Connect with the RedisClient.
     */
   private def connect() = {
     val uri = new URI(host)
@@ -40,6 +46,7 @@ class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") exten
 
   /**
     * Stores a schema bound to a subject.
+    *
     * @param schema the schema belonging to that topic.
     * @param subject the subject belonging to that schema.
     * @return true if correctly saved
@@ -50,6 +57,7 @@ class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") exten
 
   /**
     * Get a schema based on a subject.
+    *
     * @param subject the subject the schema belongs to.
     * @return None if no schema is found or an invalid schema. Otherwise it returns the schema.
     */
@@ -66,6 +74,7 @@ class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") exten
 
   /**
     * Deletes a schema.
+    *
     * @param subject the subject the schema belongs to.
     * @return true if successfully deleted, otherwise false.
     */

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/RedisSchemaExposer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/RedisSchemaExposer.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.codefeedr.pipeline.buffer.serialization.schema_exposure
+
+import java.net.URI
+
+import com.redis.RedisClient
+import org.apache.avro.Schema
+
+class RedisSchemaExposer(host: String, root: String = "codefeedr:schemas") extends SchemaExposer {
+
+  private var connection: RedisClient = _
+
+  //connect to the redis client
+  connect()
+
+  /**
+    * Connect with the RedisClien.t
+    */
+  private def connect() = {
+    val uri = new URI(host)
+    connection = new RedisClient(uri)
+  }
+
+  /**
+    * Stores a schema bound to a subject.
+    * @param schema the schema belonging to that topic.
+    * @param subject the subject belonging to that schema.
+    * @return true if correctly saved
+    */
+  override def putSchema(schema: Schema, subject: String): Boolean = {
+    connection.set(s"$root:$subject", schema.toString(true))
+  }
+
+  /**
+    * Get a schema based on a subject.
+    * @param subject the subject the schema belongs to.
+    * @return None if no schema is found or an invalid schema. Otherwise it returns the schema.
+    */
+  override def getSchema(subject: String): Option[Schema] = {
+    val schemaString = connection.get[String](s"$root:$subject")
+
+    //if no string is found, return None
+    if (schemaString.isEmpty) return None
+
+    //parse the string into a Schema
+    parseSchema(schemaString.get)
+  }
+
+
+  /**
+    * Deletes a schema.
+    * @param subject the subject the schema belongs to.
+    * @return true if successfully deleted, otherwise false.
+    */
+  override def delSchema(subject: String): Boolean = {
+    val deleted = connection.del(s"$root:$subject")
+
+    //if deleted doesnt return anything or less than 1 key is deleted, return false
+    if (deleted.isEmpty || deleted.get < 1) {
+      return false
+    }
+
+    true
+  }
+
+  /**
+    * Deletes all schemas 'under' the root.
+    */
+  override def deleteAllSchemas() = {
+    val keys = connection.keys(s"[$root]*")
+
+    if (!keys.isEmpty) {
+      keys
+        .get
+        .map(_.get)
+        .foreach(connection.del(_))
+    }
+  }
+}

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposer.scala
@@ -6,6 +6,7 @@ trait SchemaExposer {
 
   /**
     * Stores a schema bound to a subject.
+    *
     * @param schema the schema belonging to that topic.
     * @param subject the subject belonging to that schema.
     * @return true if correctly saved.
@@ -14,6 +15,7 @@ trait SchemaExposer {
 
   /**
     * Get a schema based on a subject.
+    *
     * @param subject the subject the schema belongs to.
     * @return None if no schema is found or an invalid schema. Otherwise it returns the schema.
     */
@@ -21,6 +23,7 @@ trait SchemaExposer {
 
   /**
     * Deletes a Schema.
+    *
     * @param subject the subject the schema belongs to.
     * @return true if successfully deleted, otherwise false.
     */
@@ -33,6 +36,7 @@ trait SchemaExposer {
 
   /**
     * Tries to parse a String into a Schema.
+    *
     * @param schemaString the schema string.
     * @return an option of a Schema.
     */

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposer.scala
@@ -11,7 +11,7 @@ trait SchemaExposer {
     * @param subject the subject belonging to that schema.
     * @return true if correctly saved.
     */
-  def putSchema(schema : Schema, subject : String) : Boolean
+  def put(schema : Schema, subject : String) : Boolean
 
   /**
     * Get a schema based on a subject.
@@ -19,7 +19,7 @@ trait SchemaExposer {
     * @param subject the subject the schema belongs to.
     * @return None if no schema is found or an invalid schema. Otherwise it returns the schema.
     */
-  def getSchema(subject : String) : Option[Schema]
+  def get(subject : String) : Option[Schema]
 
   /**
     * Deletes a Schema.
@@ -27,12 +27,12 @@ trait SchemaExposer {
     * @param subject the subject the schema belongs to.
     * @return true if successfully deleted, otherwise false.
     */
-  def delSchema(subject : String) : Boolean
+  def delete(subject : String) : Boolean
 
   /**
     * Deletes all schemas.
     */
-  def deleteAllSchemas()
+  def deleteAll()
 
   /**
     * Tries to parse a String into a Schema.
@@ -40,7 +40,7 @@ trait SchemaExposer {
     * @param schemaString the schema string.
     * @return an option of a Schema.
     */
-  def parseSchema(schemaString: String) : Option[Schema] = {
+  def parse(schemaString: String) : Option[Schema] = {
     try {
       val schema = new Schema.Parser().parse(schemaString)
       Some(schema)

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposer.scala
@@ -1,0 +1,47 @@
+package org.codefeedr.pipeline.buffer.serialization.schema_exposure
+
+import org.apache.avro.Schema
+
+trait SchemaExposer {
+
+  /**
+    * Stores a schema bound to a subject.
+    * @param schema the schema belonging to that topic.
+    * @param subject the subject belonging to that schema.
+    * @return true if correctly saved.
+    */
+  def putSchema(schema : Schema, subject : String) : Boolean
+
+  /**
+    * Get a schema based on a subject.
+    * @param subject the subject the schema belongs to.
+    * @return None if no schema is found or an invalid schema. Otherwise it returns the schema.
+    */
+  def getSchema(subject : String) : Option[Schema]
+
+  /**
+    * Deletes a Schema.
+    * @param subject the subject the schema belongs to.
+    * @return true if successfully deleted, otherwise false.
+    */
+  def delSchema(subject : String) : Boolean
+
+  /**
+    * Deletes all schemas.
+    */
+  def deleteAllSchemas()
+
+  /**
+    * Tries to parse a String into a Schema.
+    * @param schemaString the schema string.
+    * @return an option of a Schema.
+    */
+  def parseSchema(schemaString: String) : Option[Schema] = {
+    try {
+      val schema = new Schema.Parser().parse(schemaString)
+      Some(schema)
+    } catch {
+      case x : Throwable => None
+    }
+  }
+}

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/ZookeeperSchemaExposer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/ZookeeperSchemaExposer.scala
@@ -65,7 +65,7 @@ class ZookeeperSchemaExposer(host: String, root: String = "/codefeedr:schemas") 
     * @param subject the subject belonging to that schema.
     * @return true if correctly saved.
     */
-  override def putSchema(schema: Schema, subject: String): Boolean = {
+  override def put(schema: Schema, subject: String): Boolean = {
     val path = s"$root/$subject"
 
     //check if already exist, if so update data
@@ -90,13 +90,13 @@ class ZookeeperSchemaExposer(host: String, root: String = "/codefeedr:schemas") 
     * @param subject the subject the schema belongs to.
     * @return None if no schema is found or an invalid schema. Otherwise it returns the schema.
     */
-  override def getSchema(subject: String): Option[Schema] = {
+  override def get(subject: String): Option[Schema] = {
     try {
       //get the data from ZK
       val data = client.getData(s"$root/$subject", null, null)
 
       //parse the schema and return
-      parseSchema(new String(data))
+      parse(new String(data))
     } catch {
       case x: Throwable => return None //if path is not found
     }
@@ -108,7 +108,7 @@ class ZookeeperSchemaExposer(host: String, root: String = "/codefeedr:schemas") 
     * @param subject the subject the schema belongs to.
     * @return true if successfully deleted, otherwise false.
     */
-  override def delSchema(subject: String): Boolean = {
+  override def delete(subject: String): Boolean = {
     try {
       client.delete(s"$root/$subject", -1)
     } catch {
@@ -122,7 +122,7 @@ class ZookeeperSchemaExposer(host: String, root: String = "/codefeedr:schemas") 
   /**
     * Deletes all schemas.
     */
-  override def deleteAllSchemas() : Unit = {
+  override def deleteAll() : Unit = {
     val exists = client.exists(s"$root", false)
 
     //if not exists then return

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/ZookeeperSchemaExposer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/ZookeeperSchemaExposer.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.codefeedr.pipeline.buffer.serialization.schema_exposure
+
+import org.apache.avro.Schema
+import org.apache.zookeeper._
+import collection.JavaConverters._
+
+/**
+  * Exposes (Avro) schema's to ZooKeeper.
+  * @param host the server host of ZooKeeper.
+  * @param root the root node of the schema's
+  *             NOTE: Must start with / and only contain one '/'
+  *             DEFAULT: /codefeedr:schemas
+  */
+class ZookeeperSchemaExposer(host: String, root: String = "/codefeedr:schemas") extends SchemaExposer {
+
+  var client: ZooKeeper = _
+
+  //connect to zk
+  connect()
+
+  /**
+    * Connect with ZK server.
+    */
+  private def connect() = {
+    client = new ZooKeeper(host, 5000, new Watcher {
+      override def process(event: WatchedEvent): Unit = {}
+    })//we don't care about the watchevent
+
+
+    //create parent node
+    client.create(root,
+      Array(),
+      ZooDefs.Ids.OPEN_ACL_UNSAFE,
+      CreateMode.PERSISTENT)
+  }
+
+
+  /**
+    * Stores a schema bound to a subject.
+    *
+    * @param schema  the schema belonging to that topic.
+    * @param subject the subject belonging to that schema.
+    * @return true if correctly saved.
+    */
+  override def putSchema(schema: Schema, subject: String): Boolean = {
+    val path = s"$root/$subject"
+
+    //check if already exist, if so update data
+    val exists = client.exists(path, false)
+    if (exists != null) {
+      client.setData(path, schema.toString(true).getBytes(), -1)
+      return true
+    }
+
+    //create new node and set if it doesn't exist
+    val createdPath = client.create(path,
+      schema.toString(true).getBytes,
+      ZooDefs.Ids.OPEN_ACL_UNSAFE,
+      CreateMode.PERSISTENT)
+
+    path == createdPath
+  }
+
+  /**
+    * Get a schema based on a subject.
+    *
+    * @param subject the subject the schema belongs to.
+    * @return None if no schema is found or an invalid schema. Otherwise it returns the schema.
+    */
+  override def getSchema(subject: String): Option[Schema] = {
+    try {
+      //get the data from ZK
+      val data = client.getData(s"$root/$subject", null, null)
+
+      //parse the schema and return
+      parseSchema(new String(data))
+    } catch {
+      case x: Throwable => return None //if path is not found
+    }
+  }
+
+  /**
+    * Deletes a Schema.
+    *
+    * @param subject the subject the schema belongs to.
+    * @return true if successfully deleted, otherwise false.
+    */
+  override def delSchema(subject: String): Boolean = {
+    try {
+      client.delete(s"$root/$subject", -1)
+    } catch {
+      case x: Throwable => return false //if path doesn't exist or there is no data
+    }
+
+
+    true
+  }
+
+  /**
+    * Deletes all schemas.
+    */
+  override def deleteAllSchemas() : Unit = {
+    val exists = client.exists(s"$root", false)
+
+    //if not exists then return
+    if (exists == null) return
+
+    //get all children
+    val children = client.getChildren(s"$root", false)
+
+    //delete children
+    children
+      .asScala
+      .foreach(x => client.delete(s"$root/$x", -1))
+
+    //delete root afterwards
+    client.delete(s"$root", -1)
+  }
+}

--- a/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/ZookeeperSchemaExposer.scala
+++ b/src/main/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/ZookeeperSchemaExposer.scala
@@ -45,11 +45,16 @@ class ZookeeperSchemaExposer(host: String, root: String = "/codefeedr:schemas") 
     })//we don't care about the watchevent
 
 
-    //create parent node
-    client.create(root,
-      Array(),
-      ZooDefs.Ids.OPEN_ACL_UNSAFE,
-      CreateMode.PERSISTENT)
+    //if parent doesn't exist create it
+    val exists = client.exists(root, false)
+
+    if (exists == null) {
+      //create parent node
+      client.create(root,
+        Array(),
+        ZooDefs.Ids.OPEN_ACL_UNSAFE,
+        CreateMode.PERSISTENT)
+    }
   }
 
 

--- a/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
@@ -3,7 +3,7 @@ package org.codefeedr.pipeline
 import java.util.Properties
 
 import org.apache.flink.streaming.api.scala.DataStream
-import org.codefeedr.pipeline.buffer.{BufferType, KafkaBuffer}
+import org.codefeedr.pipeline.buffer.{BufferType, KafkaBuffer, NoAvroSerdeException}
 import org.codefeedr.plugins.{StringSource, StringType}
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.apache.flink.api.scala._
@@ -11,6 +11,8 @@ import org.apache.flink.runtime.client.JobExecutionException
 import org.apache.flink.runtime.messages.JobManagerMessages.JobResultSuccess
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, KafkaAdminClient}
+import org.codefeedr.pipeline.buffer.serialization.Serializer
+import org.codefeedr.pipeline.buffer.serialization.schema_exposure.{RedisSchemaExposer, ZookeeperSchemaExposer}
 import org.codefeedr.testUtils._
 
 import scala.collection.JavaConverters._
@@ -76,6 +78,74 @@ class PipelineTest extends FunSuite with BeforeAndAfter {
     assertThrows[JobExecutionException] {
       pipeline.start(Array("-runtime", "local"))
     }
+  }
+
+  test("Simple pipeline schema exposure test (redis)") {
+    val pipeline = simpleDAGPipeline(2)
+      .setBufferType(BufferType.Kafka)
+      .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE, "true")
+      .setBufferProperty(KafkaBuffer.SERIALIZER, Serializer.AVRO)
+      .build()
+
+    assertThrows[JobExecutionException] {
+      pipeline.start(Array("-runtime", "local"))
+    }
+
+    val exposer = new RedisSchemaExposer("redis://localhost:6379")
+
+    val schema1 = exposer.getSchema("org.codefeedr.testUtils.SimpleSourcePipelineObject")
+    val schema2 = exposer.getSchema("org.codefeedr.testUtils.SimpleTransformPipelineObject")
+
+    assert(!schema1.isEmpty)
+    assert(!schema2.isEmpty)
+  }
+
+  test("Simple pipeline schema exposure and deserialization test with JSON (redis)") {
+    val pipeline = simpleDAGPipeline(2)
+      .setBufferType(BufferType.Kafka)
+      .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE, "true")
+      .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE_DESERIALIZATION, "true")
+      .setBufferProperty(KafkaBuffer.SERIALIZER, Serializer.JSON)
+      .build()
+
+    assertThrows[NoAvroSerdeException] {
+      pipeline.start(Array("-runtime", "local"))
+    }
+  }
+
+  test("Simple pipeline schema exposure and deserialization test (redis)") {
+    val pipeline = simpleDAGPipeline(2)
+      .setBufferType(BufferType.Kafka)
+      .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE, "true")
+      .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE_DESERIALIZATION, "true")
+      .setBufferProperty(KafkaBuffer.SERIALIZER, Serializer.AVRO)
+      .build()
+
+    assertThrows[JobExecutionException] {
+      pipeline.start(Array("-runtime", "local"))
+    }
+  }
+
+  test("Simple pipeline schema exposure test (zookeeper)") {
+    val pipeline = simpleDAGPipeline(2)
+      .setBufferType(BufferType.Kafka)
+      .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE, "true")
+      .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE_SERVICE, "zookeeper")
+      .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE_HOST, "localhost:2181")
+      .setBufferProperty(KafkaBuffer.SERIALIZER, Serializer.AVRO)
+      .build()
+
+    assertThrows[JobExecutionException] {
+      pipeline.start(Array("-runtime", "local"))
+    }
+
+    val exposer = new ZookeeperSchemaExposer("localhost:2181")
+
+    val schema1 = exposer.getSchema("org.codefeedr.testUtils.SimpleSourcePipelineObject")
+    val schema2 = exposer.getSchema("org.codefeedr.testUtils.SimpleTransformPipelineObject")
+
+    assert(!schema1.isEmpty)
+    assert(!schema2.isEmpty)
   }
 
   /**

--- a/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
@@ -76,7 +76,7 @@ class PipelineTest extends FunSuite with BeforeAndAfter {
         .build()
 
     assertThrows[JobExecutionException] {
-      pipeline.start(Array("-runtime", "local"))
+      pipeline.startLocal()
     }
   }
 
@@ -88,13 +88,13 @@ class PipelineTest extends FunSuite with BeforeAndAfter {
       .build()
 
     assertThrows[JobExecutionException] {
-      pipeline.start(Array("-runtime", "local"))
+      pipeline.startLocal()
     }
 
     val exposer = new RedisSchemaExposer("redis://localhost:6379")
 
-    val schema1 = exposer.getSchema("org.codefeedr.testUtils.SimpleSourcePipelineObject")
-    val schema2 = exposer.getSchema("org.codefeedr.testUtils.SimpleTransformPipelineObject")
+    val schema1 = exposer.get("org.codefeedr.testUtils.SimpleSourcePipelineObject")
+    val schema2 = exposer.get("org.codefeedr.testUtils.SimpleTransformPipelineObject")
 
     assert(!schema1.isEmpty)
     assert(!schema2.isEmpty)
@@ -109,7 +109,7 @@ class PipelineTest extends FunSuite with BeforeAndAfter {
       .build()
 
     assertThrows[NoAvroSerdeException] {
-      pipeline.start(Array("-runtime", "local"))
+      pipeline.startLocal()
     }
   }
 
@@ -122,7 +122,7 @@ class PipelineTest extends FunSuite with BeforeAndAfter {
       .build()
 
     assertThrows[JobExecutionException] {
-      pipeline.start(Array("-runtime", "local"))
+      pipeline.startLocal()
     }
   }
 
@@ -136,13 +136,13 @@ class PipelineTest extends FunSuite with BeforeAndAfter {
       .build()
 
     assertThrows[JobExecutionException] {
-      pipeline.start(Array("-runtime", "local"))
+      pipeline.startLocal()
     }
 
     val exposer = new ZookeeperSchemaExposer("localhost:2181")
 
-    val schema1 = exposer.getSchema("org.codefeedr.testUtils.SimpleSourcePipelineObject")
-    val schema2 = exposer.getSchema("org.codefeedr.testUtils.SimpleTransformPipelineObject")
+    val schema1 = exposer.get("org.codefeedr.testUtils.SimpleSourcePipelineObject")
+    val schema2 = exposer.get("org.codefeedr.testUtils.SimpleTransformPipelineObject")
 
     assert(!schema1.isEmpty)
     assert(!schema2.isEmpty)

--- a/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
@@ -88,7 +88,7 @@ class PipelineTest extends FunSuite with BeforeAndAfter {
       .build()
 
     assertThrows[JobExecutionException] {
-      pipeline.startLocal()
+      pipeline.start(Array("-runtime", "local"))
     }
 
     val exposer = new RedisSchemaExposer("redis://localhost:6379")

--- a/src/test/scala/org/codefeedr/pipeline/buffer/KafkaBufferTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/buffer/KafkaBufferTest.scala
@@ -39,7 +39,7 @@ class KafkaBufferTest extends FunSuite with BeforeAndAfter {
     client = AdminClient.create(props)
 
     //setup simple kafkabuffer
-    kafkaBuffer = new KafkaBuffer[StringType](new PipelineBuilder().append(new SimpleSourcePipelineObject()).build(), "")
+    kafkaBuffer = new KafkaBuffer[StringType](new PipelineBuilder().append(new SimpleSourcePipelineObject()).build(), "test-subject")
   }
 
 
@@ -49,6 +49,10 @@ class KafkaBufferTest extends FunSuite with BeforeAndAfter {
     assert(!exists(uuid))
     kafkaBuffer.checkAndCreateSubject(uuid, "localhost:9092")
     assert(exists(uuid))
+  }
+
+  test ("A schema should correctly be exposed") {
+    assert(kafkaBuffer.exposeSchema())
   }
 
   /**

--- a/src/test/scala/org/codefeedr/pipeline/buffer/KafkaBufferTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/buffer/KafkaBufferTest.scala
@@ -51,6 +51,12 @@ class KafkaBufferTest extends FunSuite with BeforeAndAfter {
     assert(exists(uuid))
   }
 
+  test ("A non-existent schema should throw an exception") {
+    assertThrows[SchemaNotFoundException] {
+      kafkaBuffer.getSchema("nOnExistent")
+    }
+  }
+
   test ("A schema should correctly be exposed") {
     assert(kafkaBuffer.exposeSchema())
   }

--- a/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/RedisSchemaExposerTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/RedisSchemaExposerTest.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.codefeedr.pipeline.buffer.serialization.schema_exposure
+
+class RedisSchemaExposerTest extends SchemaExposerTest {
+
+  override def getSchemaExposer(): SchemaExposer = new RedisSchemaExposer("redis://localhost:6379")
+}

--- a/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposerTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposerTest.scala
@@ -21,6 +21,7 @@ package org.codefeedr.pipeline.buffer.serialization.schema_exposure
 import org.apache.avro.Schema
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
 
+
 abstract class SchemaExposerTest extends FunSuite with BeforeAndAfter {
 
   val schema = """{

--- a/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposerTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposerTest.scala
@@ -66,25 +66,25 @@ abstract class SchemaExposerTest extends FunSuite with BeforeAndAfter {
     exposer = getSchemaExposer()
 
     parsedSchema = exposer
-      .parseSchema(schema)
+      .parse(schema)
       .get
 
     parsedSchema2 = exposer
-      .parseSchema(differentSchema)
+      .parse(differentSchema)
       .get
   }
 
   after {
-    exposer.deleteAllSchemas()
+    exposer.deleteAll()
   }
 
   test("A simple schema should be correctly saved") {
     //put the schema
-    exposer.putSchema(parsedSchema, subject)
+    exposer.put(parsedSchema, subject)
 
     //if I get the schema, it should be the same
-    assert(exposer.getSchema(subject).get == parsedSchema)
-    assert(exposer.getSchema(subject).get != parsedSchema2)
+    assert(exposer.get(subject).get == parsedSchema)
+    assert(exposer.get(subject).get != parsedSchema2)
   }
 
   test("A simple schema should be correctly overwritten") {
@@ -92,54 +92,54 @@ abstract class SchemaExposerTest extends FunSuite with BeforeAndAfter {
     assert(parsedSchema2 != parsedSchema)
 
     //put the schema
-    exposer.putSchema(parsedSchema, subject)
+    exposer.put(parsedSchema, subject)
 
     //if I get the schema, it should be the same
-    assert(exposer.getSchema(subject).get == parsedSchema)
+    assert(exposer.get(subject).get == parsedSchema)
 
     //put the different schema
-    exposer.putSchema(parsedSchema2, subject)
+    exposer.put(parsedSchema2, subject)
 
     //if I get the schema, it should not be the same as the original
-    assert(exposer.getSchema(subject).get != parsedSchema)
-    assert(exposer.getSchema(subject).get == parsedSchema2)
+    assert(exposer.get(subject).get != parsedSchema)
+    assert(exposer.get(subject).get == parsedSchema2)
   }
 
 
   test("A simple schema should be correctly deleted") {
     //put the schema
-    assert(exposer.putSchema(parsedSchema, subject))
+    assert(exposer.put(parsedSchema, subject))
 
     //it should be properly deleted
-    assert(exposer.delSchema(subject))
+    assert(exposer.delete(subject))
   }
 
   test("A simple schema cannot be deleted if it is not there") {
     //it should be properly deleted
-    assert(!exposer.delSchema(subject))
+    assert(!exposer.delete(subject))
   }
 
   test("Get a schema on a non existent subject should return None") {
-    assert(exposer.getSchema("IDoNoTeXiSt") == None)
+    assert(exposer.get("IDoNoTeXiSt") == None)
   }
 
   test("An invalid schema should return None") {
-    assert(exposer.parseSchema("iNVaLIdScHemA{}$%:)") == None)
+    assert(exposer.parse("iNVaLIdScHemA{}$%:)") == None)
   }
 
   test("All schema's should be properly deleted") {
     //put the schema
-    assert(exposer.putSchema(parsedSchema, subject))
-    exposer.deleteAllSchemas()
-    assert(exposer.getSchema(subject) == None)
+    assert(exposer.put(parsedSchema, subject))
+    exposer.deleteAll()
+    assert(exposer.get(subject) == None)
   }
 
   test("All schema's should be properly deleted even if called twice") {
     //put the schema
-    assert(exposer.putSchema(parsedSchema, subject))
-    exposer.deleteAllSchemas()
-    exposer.deleteAllSchemas()
-    assert(exposer.getSchema(subject) == None)
+    assert(exposer.put(parsedSchema, subject))
+    exposer.deleteAll()
+    exposer.deleteAll()
+    assert(exposer.get(subject) == None)
   }
 
 

--- a/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposerTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposerTest.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.codefeedr.pipeline.buffer.serialization.schema_exposure
+
+import org.apache.avro.Schema
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+case class Person(name : String, age : Int)
+
+abstract class SchemaExposerTest extends FunSuite with BeforeAndAfter {
+
+  val schema = """{
+                   "type": "record",
+                   "name": "User",
+                   "fields": [
+                     {
+                         "name": "name",
+                         "type": "string"
+                     },
+                     {
+                         "name": "age",
+                         "type": "int"
+                     }
+                   ]
+                 }"""
+
+  var exposer : SchemaExposer = _
+  var parsedSchema : Schema = _
+  val subject = "testSubject"
+
+  def getSchemaExposer() : SchemaExposer
+
+  before {
+    exposer = getSchemaExposer()
+    parsedSchema = exposer
+      .parseSchema(schema)
+      .get
+  }
+
+  after {
+    exposer.deleteAllSchemas()
+  }
+
+  test("A simple schema should be correctly saved") {
+    //put the schema
+    exposer.putSchema(parsedSchema, subject)
+
+    //if I get the schema, it should be the same
+    assert(exposer.getSchema(subject).get == parsedSchema)
+  }
+
+  test("A simple schema should be correctly deleted") {
+    //put the schema
+    assert(exposer.putSchema(parsedSchema, subject))
+
+    //it should be properly deleted
+    assert(exposer.delSchema(subject))
+  }
+
+  test("A simple schema cannot be deleted if it is not there") {
+    //it should be properly deleted
+    assert(!exposer.delSchema(subject))
+  }
+
+  test("Get a schema on a non existent subject should return None") {
+    assert(exposer.getSchema("IDoNoTeXiSt") == None)
+  }
+
+  test("An invalid schema should return None") {
+    assert(exposer.parseSchema("iNVaLIdScHemA{}$%:)") == None)
+  }
+
+
+}

--- a/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposerTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/SchemaExposerTest.scala
@@ -134,5 +134,13 @@ abstract class SchemaExposerTest extends FunSuite with BeforeAndAfter {
     assert(exposer.getSchema(subject) == None)
   }
 
+  test("All schema's should be properly deleted even if called twice") {
+    //put the schema
+    assert(exposer.putSchema(parsedSchema, subject))
+    exposer.deleteAllSchemas()
+    exposer.deleteAllSchemas()
+    assert(exposer.getSchema(subject) == None)
+  }
+
 
 }

--- a/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/ZookeeperSchemaExposerTest.scala
+++ b/src/test/scala/org/codefeedr/pipeline/buffer/serialization/schema_exposure/ZookeeperSchemaExposerTest.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.codefeedr.pipeline.buffer.serialization.schema_exposure
+
+class ZookeeperSchemaExposerTest extends SchemaExposerTest {
+  override def getSchemaExposer(): SchemaExposer = new ZookeeperSchemaExposer("localhost:2181")
+}


### PR DESCRIPTION
Currently implemented Schema exposure through Redis. Still WIP.

To do:
- ~~~Implement SchemaExposure for Zookeeper~~~
- ~~~Implement & make it configurable to choose from ZK/Redis in the KafkaBuffer (maybe in any Buffer?)~~~
- ~~~Implement & make it configurable to (de-)serialize using the schema~~~
- ~~~Implement & make it configurable to either generate an Avro schema or specify a file with a Schema~~~ didn't add this yet
- ~~~Add correct exceptions + warnings~~~
    - ~~~JSON + Schema Exposure => Warning~~~ Won't be adding a warning since we don't have a log system (yet).
    - ~~~JSON + Schema Exposure + (de)serialize using that Schema => Exception~~~


Related to #4 