### PR TITLE
Updated to Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ scala:
   - 2.12.8
 sudo: required
 dist: trusty
+jdk: oraclejdk8
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: scala
-scala: 2.11.11
+scala:
+  - 2.11.11
+  - 2.12.8
 sudo: required
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,6 @@ before_install:
   - docker-compose -f "containers/kafka/docker-compose-single-broker.yml" up -d
   - docker ps -a
 
-matrix:
-  include:
-    - env: SCALA_VERSION=2.11.11
-      os: linux
-      jdk: oraclejdk8
-
 before_script:
   - sleep 10
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ ThisBuild / homepage := Some(url("https://github.com/codefeedr/codefeedr"))
 
 ThisBuild / version := "0.1-SNAPSHOT"
 ThisBuild / organization := "org.codefeedr"
-ThisBuild / scalaVersion := "2.11.11"
+ThisBuild / scalaVersion := "2.12.8"
 
 
 parallelExecution in Test := false
@@ -222,7 +222,7 @@ lazy val dependencies =
     val kryoChill          = "com.twitter"               %% "chill"                          % "0.9.1"
 
     val scalactic          = "org.scalactic"             %% "scalactic"                      % "3.0.1"           % Test
-    val scalatest          = "org.scalatest"             %% "scalatest"                      % "3.0.1"           % Test
+    val scalatest          = "org.scalatest"             %% "scalatest"                      % "3.0.5"           % Test
     val scalamock          = "org.scalamock"             %% "scalamock"                      % "4.1.0"           % Test
     val mockito            = "org.mockito"                % "mockito-all"                    % "1.10.19"         % Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,10 @@
 import sbt.Credentials
 import sbt.Keys.{credentials, name, publishMavenStyle}
 
+lazy val scala212 = "2.12.8"
+lazy val scala211 = "2.11.11"
+lazy val supportedScalaVersions = List(scala211, scala212)
+
 ThisBuild / organization := "org.codefeedr"
 ThisBuild / organizationName := "CodeFeedr"
 ThisBuild / organizationHomepage := Some(url("http://codefeedr.org"))
@@ -27,7 +31,7 @@ ThisBuild / homepage := Some(url("https://github.com/codefeedr/codefeedr"))
 
 ThisBuild / version := "0.1-SNAPSHOT"
 ThisBuild / organization := "org.codefeedr"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := scala212
 
 
 parallelExecution in Test := false
@@ -257,15 +261,15 @@ lazy val commonSettings = Seq(
     "Artima Maven Repository"                 at "http://repo.artima.com/releases",
     Resolver.mavenLocal
   ),
-  ThisBuild / isSnapshot := true,
   publishMavenStyle in ThisBuild := true,
   publishTo in ThisBuild := Some(
-    if (isSnapshot.value)
+    if (version.value.trim.endsWith("SNAPSHOT"))
       Opts.resolver.sonatypeSnapshots
     else
       Opts.resolver.sonatypeStaging
   ),
-  ThisBuild / pomIncludeRepository := { _ => false }
+  ThisBuild / pomIncludeRepository := { _ => false },
+  crossScalaVersions := supportedScalaVersions
 )
 
 lazy val noPublishSettings = Seq(
@@ -273,7 +277,8 @@ lazy val noPublishSettings = Seq(
   publishLocal := {},
   publishArtifact := false,
   // sbt-pgp's publishSigned task needs this defined even though it is not publishing.
-  publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
+  publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo"))),
+  crossScalaVersions := Nil
 )
 
 lazy val compilerOptions = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ val projectPrefix = "codefeedr-"
 val pluginPrefix = projectPrefix + "plugin-"
 
 lazy val root = (project in file("."))
-  .settings(settings)
+  .settings(settings ++ noPublishSettings)
   .aggregate(core,
     pluginRss,
     pluginMongodb,
@@ -266,6 +266,14 @@ lazy val commonSettings = Seq(
       Opts.resolver.sonatypeStaging
   ),
   ThisBuild / pomIncludeRepository := { _ => false }
+)
+
+lazy val noPublishSettings = Seq(
+  publish := {},
+  publishLocal := {},
+  publishArtifact := false,
+  // sbt-pgp's publishSigned task needs this defined even though it is not publishing.
+  publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
 )
 
 lazy val compilerOptions = Seq(

--- a/codefeedr-core/src/test/scala/org/codefeedr/buffer/serialization/BsonSerdeTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/buffer/serialization/BsonSerdeTest.scala
@@ -23,16 +23,17 @@ import java.util.Date
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
+
+private case class SimpleCaseClassBson(str: String, i: Int)
+private case class ComplexCaseClass(str: String, i : Option[Int], l : List[Date])
+
 class BsonSerdeTest extends FunSuite with BeforeAndAfter {
 
-  private case class SimpleCaseClass(str: String, i: Int)
-  private case class ComplexCaseClass(str: String, i : Option[Int], l : List[Date])
-
-  private var serde : BsonSerde[SimpleCaseClass] = _
+  private var serde : BsonSerde[SimpleCaseClassBson] = _
   private var serde2 : BsonSerde[ComplexCaseClass] = _
 
   before {
-    serde = BsonSerde[SimpleCaseClass]
+    serde = BsonSerde[SimpleCaseClassBson]
     serde2 = BsonSerde[ComplexCaseClass]
   }
 
@@ -55,7 +56,7 @@ class BsonSerdeTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Deserializes simple serialized values") {
-    val value = SimpleCaseClass("hello", 42)
+    val value = SimpleCaseClassBson("hello", 42)
 
     val serialized = serde.serialize(value)
     val deserialized = serde.deserialize(serialized)
@@ -64,7 +65,7 @@ class BsonSerdeTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Simple typeinformation check") {
-    val typeInformation = TypeInformation.of(classOf[SimpleCaseClass])
+    val typeInformation = TypeInformation.of(classOf[SimpleCaseClassBson])
 
     assert(typeInformation == serde.getProducedType)
   }

--- a/codefeedr-core/src/test/scala/org/codefeedr/buffer/serialization/JSONSerdeTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/buffer/serialization/JSONSerdeTest.scala
@@ -21,9 +21,9 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 
+private case class SimpleCaseClass(str: String, i: Int)
 
 class JSONSerdeTest extends FunSuite with BeforeAndAfter {
-  private case class SimpleCaseClass(str: String, i: Int)
 
   private var serde : JSONSerde[SimpleCaseClass] = null
 


### PR DESCRIPTION
Related issue(s): #153 
### Description of changes
<!-- Please provide a description of the change here. -->
- Update to Scala 2.12.8
- Added cross versions for 2.11.11 and 2.12.8
- Now we're able to publish both 2.11 and 2.12 (`+publishSigned`)

### Check-list

_Please make sure to review and check all of these items:_

- [x] Are the updated classes tested?
- [x] Are the updated classes documented & properly formatted?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._
