### PR TITLE
Expose Stage variables through Context object

### DIFF
--- a/codefeedr-core/src/main/scala/org/codefeedr/buffer/BufferFactory.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/buffer/BufferFactory.scala
@@ -57,8 +57,9 @@ class BufferFactory[+In <: Serializable with AnyRef,
       "Buffer factory requires a sink object to determine buffer location")
 
     /** Get the id to read from or write to. */
-    val subject = relatedStage.getId
-    val groupIdFinal = if (groupId != null) groupId else stage.id
+    val subject = relatedStage.getContext.stageId
+    val groupIdFinal =
+      if (groupId != null) groupId else stage.getContext.stageId
 
     // Create the correct buffer.
     pipeline.bufferType match {

--- a/codefeedr-core/src/main/scala/org/codefeedr/pipeline/Pipeline.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/pipeline/Pipeline.scala
@@ -143,7 +143,7 @@ case class Pipeline(var name: String,
 
   /** Validates the uniqueness of the stage IDs, needed for clustered running. */
   def validateUniqueness(): Unit = {
-    val list = getNodes.map(_.id)
+    val list = getNodes.map(_.getContext.stageId)
     val uniqList = list.distinct
     val overlap = list.diff(uniqList)
 
@@ -161,14 +161,14 @@ case class Pipeline(var name: String,
     if (asException) {
       val contents = getNodes
         .map { item =>
-          '"' + item.id + '"'
+          '"' + item.getContext.stageId + '"'
         }
         .mkString(",")
       val json = s"[$contents]"
 
       throw PipelineListException(json)
     } else {
-      getNodes.foreach(item => println(item.id))
+      getNodes.foreach(item => println(item.getContext.stageId))
     }
   }
 
@@ -245,7 +245,8 @@ case class Pipeline(var name: String,
     val optObj = graph.nodes.find { node =>
       node
         .asInstanceOf[Stage[Serializable with AnyRef, Serializable with AnyRef]]
-        .id == stage
+        .getContext
+        .stageId == stage
     }
 
     // If cannot be find, throw an exception.

--- a/codefeedr-core/src/main/scala/org/codefeedr/pipeline/PipelineBuilder.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/pipeline/PipelineBuilder.scala
@@ -149,17 +149,17 @@ class PipelineBuilder extends Logging {
 
   /** Set a stage property.
     *
-    * @param id The id of the stage.
+    * @param id The stage to assign the property to.
     * @param key Key of the property.
     * @param value Value of the property.
     * @return This builder instance.
     */
-  def setStageProperty(id: String,
+  def setStageProperty(stage: Stage[_, _],
                        key: String,
                        value: String): PipelineBuilder = {
 
-    val properties = stageProperties.getOrElse(id, new Properties())
-    stageProperties.put(id, properties.set(key, value))
+    val properties = stageProperties.getOrElse(stage.id, new Properties())
+    stageProperties.put(stage.id, properties.set(key, value))
 
     this
   }
@@ -249,7 +249,7 @@ class PipelineBuilder extends Logging {
   def appendSource[In <: Serializable with AnyRef: ClassTag: TypeTag](
       input: StreamExecutionEnvironment => DataStream[In]): PipelineBuilder = {
     val pipelineItem = new InputStage[In] {
-      override def main(): DataStream[In] = input(this.environment)
+      override def main(context: Context): DataStream[In] = input(context.env)
     }
 
     append(pipelineItem)

--- a/codefeedr-core/src/main/scala/org/codefeedr/pipeline/Stage.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/pipeline/Stage.scala
@@ -73,7 +73,7 @@ protected[codefeedr] abstract class Stage[
     *
     * @return The properties of this stage.
     */
-  def properties: Properties =
+  private def properties: Properties =
     if (pipeline != null) pipeline.propertiesOf(this) else null
 
   /** Setups the pipeline object with a pipeline.

--- a/codefeedr-core/src/main/scala/org/codefeedr/pipeline/Stage.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/pipeline/Stage.scala
@@ -19,12 +19,27 @@
 package org.codefeedr.pipeline
 
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.scala.{
+  DataStream,
+  StreamExecutionEnvironment
+}
 import org.codefeedr.Properties
 import org.codefeedr.buffer.BufferFactory
 
 import scala.reflect.{ClassTag, classTag}
 import scala.reflect.runtime.universe._
+
+/** The context of this stage.
+  *
+  * @param env The execution environment it is running in.
+  * @param stageId the name of this stage.
+  * @param stageProperties the properties of this stage.
+  * @param pipeline the pipeline this stage belongs to.
+  */
+case class Context(env: StreamExecutionEnvironment = null,
+                   stageId: String,
+                   stageProperties: Properties = null,
+                   pipeline: Pipeline = null)
 
 /** This class represents a stage within a pipeline. I.e. a node in the graph.
   *
@@ -43,20 +58,23 @@ protected[codefeedr] abstract class Stage[
   val outType: Type = typeOf[Out]
 
   /** The pipeline this stage belongs to. */
-  var pipeline: Pipeline = _
+  private var pipeline: Pipeline = null
 
-  /** Get the StreamExecutionEnvironment. */
-  def environment = pipeline.environment
+  /** Get the StreamExecutionEnvironment if the pipeline already exists. */
+  private def environment = if (pipeline != null) pipeline.environment else null
+
+  /** Get the Context of this stage. */
+  def getContext: Context = Context(environment, id, properties, pipeline)
 
   /** Get the id of this stage */
-  def id: String = stageId.getOrElse(getClass.getName)
+  protected[codefeedr] val id: String = stageId.getOrElse(getClass.getName)
 
-  /** Get the properties of this stage.
+  /** Get the properties of this stage if the pipeline already exists.
     *
     * @return The properties of this stage.
     */
   def properties: Properties =
-    pipeline.propertiesOf(this)
+    if (pipeline != null) pipeline.propertiesOf(this) else null
 
   /** Setups the pipeline object with a pipeline.
     *
@@ -146,13 +164,6 @@ protected[codefeedr] abstract class Stage[
 
     buffer.getSink
   }
-
-  /** Get the sink subject used by the buffer.
-    * This is also used for child objects to read from the buffer again.
-    *
-    * @return Sink subject which is basically the stage id.
-    */
-  def getId: String = this.id
 
   /** Returns the buffer source of this stage.
     *

--- a/codefeedr-core/src/main/scala/org/codefeedr/stages/InputStage.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/stages/InputStage.scala
@@ -19,7 +19,7 @@
 package org.codefeedr.stages
 
 import org.apache.flink.streaming.api.scala.DataStream
-import org.codefeedr.pipeline.Stage
+import org.codefeedr.pipeline.{Context, Stage}
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
@@ -42,13 +42,13 @@ abstract class InputStage[Out <: Serializable with AnyRef: ClassTag: TypeTag](
     * @return The transformed stream with type Out.
     */
   override def transform(source: DataStream[Nothing]): DataStream[Out] = {
-    main()
+    main(getContext)
   }
 
   /** Creates a DataStream with type Out.
     *
     * @return A newly created DataStream.
     */
-  def main(): DataStream[Out]
+  def main(context: Context): DataStream[Out]
 
 }

--- a/codefeedr-core/src/main/scala/org/codefeedr/stages/kafka/KafkaInput.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/stages/kafka/KafkaInput.scala
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer011
 import org.codefeedr.buffer.serialization.Serializer
+import org.codefeedr.pipeline.Context
 import org.codefeedr.stages.InputStage
 
 import scala.reflect.runtime.universe._
@@ -52,8 +53,8 @@ class KafkaInput[T <: Serializable with AnyRef: ClassTag: TypeTag](
   private val serde = Serializer.getSerde[T](serializer)
 
   //add flink kafka consumer
-  override def main(): DataStream[T] = {
-    pipeline.environment
+  override def main(context: Context): DataStream[T] = {
+    context.env
       .addSource(new FlinkKafkaConsumer011[T](topic, serde, properties))
   }
 

--- a/codefeedr-core/src/main/scala/org/codefeedr/stages/utilities/SeqInput.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/stages/utilities/SeqInput.scala
@@ -20,6 +20,7 @@ package org.codefeedr.stages.utilities
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala.DataStream
+import org.codefeedr.pipeline.Context
 import org.codefeedr.stages.InputStage
 
 import scala.reflect.{ClassTag, Manifest}
@@ -38,7 +39,7 @@ class SeqInput[
     *
     * @return A newly created DataStream.
     */
-  override def main(): DataStream[T] = {
-    pipeline.environment.fromCollection(seq)
+  override def main(context: Context): DataStream[T] = {
+    context.env.fromCollection(seq)
   }
 }

--- a/codefeedr-core/src/main/scala/org/codefeedr/stages/utilities/StringInput.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/stages/utilities/StringInput.scala
@@ -19,6 +19,7 @@
 package org.codefeedr.stages.utilities
 
 import org.apache.flink.streaming.api.scala.{DataStream, _}
+import org.codefeedr.pipeline.Context
 import org.codefeedr.stages.InputStage
 
 /** Simple String wrapper case class. */
@@ -35,10 +36,10 @@ class StringInput(str: String = "", stageId: Option[String] = None)
     *
     * @return A newly created DataStream.
     */
-  override def main(): DataStream[StringType] = {
+  override def main(context: Context): DataStream[StringType] = {
     val list = str.split("[ \n]")
 
-    pipeline.environment
+    context.env
       .fromCollection(list)
       .map(StringType(_))
   }

--- a/codefeedr-core/src/test/scala/org/codefeedr/buffer/BufferFactoryTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/buffer/BufferFactoryTest.scala
@@ -58,7 +58,7 @@ class BufferFactoryTest extends FunSuite with BeforeAndAfter {
     val factory = new BufferFactory(pipeline, nodeA, nodeB)
 
     // created for nodeB sink, so should have subject of nodeB
-    val nodeSubject = nodeB.getId
+    val nodeSubject = nodeB.getContext.stageId
     val buffer = factory.create[StringType]()
 
     assert(buffer.isInstanceOf[KafkaBuffer[StringType]])

--- a/codefeedr-core/src/test/scala/org/codefeedr/buffer/KafkaBufferTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/buffer/KafkaBufferTest.scala
@@ -198,17 +198,15 @@ class StringCollectSink extends SinkFunction[StringType] {
   }
 }
 
-class NumberInput() extends InputStage[StringType] {
-  val idd = UUID.randomUUID().toString
+class NumberInput()
+    extends InputStage[StringType](Some(UUID.randomUUID().toString)) {
   val numberSource = new NumberSource()
 
-  override def main(): DataStream[StringType] = {
-    pipeline.environment.addSource(numberSource)
+  override def main(
+      context: org.codefeedr.pipeline.Context): DataStream[StringType] = {
+    context.env.addSource(numberSource)
   }
 
-  override def getId: String = {
-    idd
-  }
 }
 
 class NumberSource() extends SourceFunction[StringType] {

--- a/codefeedr-core/src/test/scala/org/codefeedr/pipeline/DirectedAcyclicGraphTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/pipeline/DirectedAcyclicGraphTest.scala
@@ -32,8 +32,8 @@ class DirectedAcyclicGraphTest extends FunSuite {
   val nodeD = "d"
 
   class NothingStringType extends InputStage[StringType] {
-    override def main(): DataStream[StringType] = {
-      environment.fromCollection(Seq(StringType("a")))
+    override def main(context: Context): DataStream[StringType] = {
+      context.env.fromCollection(Seq(StringType("a")))
     }
   }
 
@@ -52,7 +52,7 @@ class DirectedAcyclicGraphTest extends FunSuite {
   }
 
   class NothingIntType extends InputStage[IntType] {
-    override def main(): DataStream[IntType] = null
+    override def main(context: Context): DataStream[IntType] = null
   }
 
   test("Added nodes are testable") {

--- a/codefeedr-core/src/test/scala/org/codefeedr/pipeline/PipelineBuilderTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/pipeline/PipelineBuilderTest.scala
@@ -86,8 +86,8 @@ class PipelineBuilderTest extends FunSuite with BeforeAndAfter with Matchers {
     val pipeline = builder
       .append(stage)
       .disablePipelineVerification()
-      .setStageProperty(stage.id, "key", "value")
-      .setStageProperty(stage.id, "anotherKey", "true")
+      .setStageProperty(stage, "key", "value")
+      .setStageProperty(stage, "anotherKey", "true")
       .build()
 
     assert(pipeline.propertiesOf(stage).get("key").get == "value")
@@ -310,6 +310,6 @@ class PipelineBuilderTest extends FunSuite with BeforeAndAfter with Matchers {
       //      .setProperty("hello", "world")
       .build()
 
-    assert(a.id == "testId")
+    assert(a.getContext.stageId == "testId")
   }
 }

--- a/codefeedr-core/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
@@ -48,8 +48,8 @@ import scala.collection.JavaConverters._
 
 class StageOne(name: String, input: Seq[String])
     extends InputStage[StringType](Some(name)) {
-  override def main(): DataStream[StringType] = {
-    this.environment
+  override def main(context: Context): DataStream[StringType] = {
+    context.env
       .fromCollection(input.map(StringType(_)))
   }
 }

--- a/codefeedr-core/src/test/scala/org/codefeedr/pipeline/StageTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/pipeline/StageTest.scala
@@ -102,7 +102,7 @@ class StageTest extends FunSuite {
 
     stage.setUp(pipeline)
 
-    assert(stage.properties.get("a").get == "b")
-    assert(stage.properties.get("c").isEmpty)
+    assert(stage.getContext.stageProperties.get("a").get == "b")
+    assert(stage.getContext.stageProperties.get("c").isEmpty)
   }
 }

--- a/codefeedr-core/src/test/scala/org/codefeedr/pipeline/StageTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/pipeline/StageTest.scala
@@ -49,7 +49,7 @@ class StageTest extends FunSuite {
   class StringTypeStage extends Stage[Nothing, StringType] {
     override def transform(
         source: DataStream[Nothing]): DataStream[StringType] = {
-      environment.fromCollection(Seq(StringType("a")))
+      getContext.env.fromCollection(Seq(StringType("a")))
     }
   }
 
@@ -86,16 +86,17 @@ class StageTest extends FunSuite {
   test("Setting id attributed propagates") {
     val a = new SimpleSourceStage(Some("testId"))
 
-    assert(a.id == "testId")
+    assert(a.getContext.stageId == "testId")
   }
 
   test("Properties should be properly propagated.") {
     val stage = new SimpleSourceStage(Some("ha"))
+    val diffStage = new SimpleSourceStage(Some("other"))
 
     val pipeline = new PipelineBuilder()
       .disablePipelineVerification()
-      .setStageProperty("ha", "a", "b")
-      .setStageProperty("no", "c", "d")
+      .setStageProperty(stage, "a", "b")
+      .setStageProperty(diffStage, "c", "d")
       .append(stage)
       .build()
 

--- a/codefeedr-core/src/test/scala/org/codefeedr/stages/InputStageTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/stages/InputStageTest.scala
@@ -19,7 +19,7 @@
 package org.codefeedr.stages
 
 import org.apache.flink.streaming.api.scala.DataStream
-import org.codefeedr.pipeline.PipelineBuilder
+import org.codefeedr.pipeline.{Context, PipelineBuilder}
 import org.codefeedr.stages.utilities.StringType
 import org.codefeedr.testUtils.CodeHitException
 import org.scalatest.FunSuite
@@ -27,7 +27,7 @@ import org.scalatest.FunSuite
 class InputStageTest extends FunSuite {
 
   class MyInputStage extends InputStage[StringType] {
-    override def main(): DataStream[StringType] = {
+    override def main(context: Context): DataStream[StringType] = {
       throw CodeHitException()
     }
   }

--- a/codefeedr-core/src/test/scala/org/codefeedr/testUtils/PipelineObjects.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/testUtils/PipelineObjects.scala
@@ -42,8 +42,8 @@ final case class CodeHitException() extends RuntimeException
 //a simple test source which generates some StringType messages
 class SimpleSourceStage(stageId: Option[String] = None)
     extends InputStage[StringType](stageId) {
-  override def main(): DataStream[StringType] = {
-    pipeline.environment.addSource {
+  override def main(context: Context): DataStream[StringType] = {
+    context.env.addSource {
       new RichSourceFunction[StringType] {
         override def run(
             ctx: SourceFunction.SourceContext[StringType]): Unit = {
@@ -96,7 +96,7 @@ class HitObjectTest extends Stage[Nothing, Nothing] {
 class FlinkCrashObjectTest extends Stage[Nothing, StringType] {
   override def transform(
       source: DataStream[Nothing]): DataStream[StringType] = {
-    pipeline.environment
+    getContext.env
       .fromCollection[String](Seq("a", "b"))
       .map { a =>
         throw CodeHitException()

--- a/codefeedr-plugins/codefeedr-github/src/main/scala/org/codefeedr/plugins/github/stages/GitHubEventsInput.scala
+++ b/codefeedr-plugins/codefeedr-github/src/main/scala/org/codefeedr/plugins/github/stages/GitHubEventsInput.scala
@@ -20,6 +20,7 @@ package org.codefeedr.plugins.github.stages
 
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.DataStream
+import org.codefeedr.pipeline.Context
 import org.codefeedr.plugins.github.GitHubProtocol.Event
 import org.codefeedr.plugins.github.events.EventSource
 import org.codefeedr.stages.InputStage
@@ -41,12 +42,12 @@ class GitHubEventsInput(numOfPolls: Int = -1,
   /**
     * Add (GitHub) EventSource.
     */
-  override def main(): DataStream[Event] = {
-    pipeline.environment
+  override def main(context: Context): DataStream[Event] = {
+    context.env
       .addSource(
         new EventSource(numOfPolls,
                         waitTime,
-                        pipeline.keyManager,
+                        context.pipeline.keyManager,
                         duplicateFilter,
                         duplicateCheckSize))
   }

--- a/codefeedr-plugins/codefeedr-github/src/main/scala/org/codefeedr/plugins/github/stages/GitHubIssueCommentDelay.scala
+++ b/codefeedr-plugins/codefeedr-github/src/main/scala/org/codefeedr/plugins/github/stages/GitHubIssueCommentDelay.scala
@@ -69,7 +69,6 @@ class GitHubIssueCommentDelay
     * Sets the correct event time.
     */
   def setEventTime() =
-    pipeline.environment.setStreamTimeCharacteristic(
-      TimeCharacteristic.EventTime)
+    getContext.env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
 }

--- a/codefeedr-plugins/codefeedr-github/src/test/scala/org/codefeedr/plugins/github/stages/GitHubEventToPushEventTest.scala
+++ b/codefeedr-plugins/codefeedr-github/src/test/scala/org/codefeedr/plugins/github/stages/GitHubEventToPushEventTest.scala
@@ -24,7 +24,7 @@ import java.util
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.scala.DataStream
-import org.codefeedr.pipeline.PipelineBuilder
+import org.codefeedr.pipeline.{Context, PipelineBuilder}
 import org.codefeedr.plugins.github.GitHubProtocol.{Event, PushEvent}
 import org.codefeedr.plugins.github.requests.EventService
 import org.codefeedr.stages.InputStage
@@ -54,11 +54,11 @@ class SimpleEventSource(fileName: String) extends InputStage[Event] {
   val stream: InputStream = getClass.getResourceAsStream(fileName)
   val sampleEvents: String = Source.fromInputStream(stream).getLines.mkString
 
-  override def main(): DataStream[Event] = {
+  override def main(context: Context): DataStream[Event] = {
     val events = new EventService(false, null)
       .parseEvents(sampleEvents)
 
-    pipeline.environment.fromCollection(events)
+    context.env.fromCollection(events)
   }
 }
 object PushEventCollectSink {

--- a/codefeedr-plugins/codefeedr-mongodb/src/main/scala/org/codefeedr/plugins/mongodb/stages/MongoInput.scala
+++ b/codefeedr-plugins/codefeedr-mongodb/src/main/scala/org/codefeedr/plugins/mongodb/stages/MongoInput.scala
@@ -20,6 +20,7 @@ package org.codefeedr.plugins.mongodb.stages
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.scala.DataStream
+import org.codefeedr.pipeline.Context
 import org.codefeedr.plugins.mongodb.{BaseMongoSource, MongoQuery}
 import org.codefeedr.stages.InputStage
 
@@ -45,13 +46,13 @@ class MongoInput[
     stageId: Option[String] = None)
     extends InputStage[T](stageId) {
 
-  override def main(): DataStream[T] = {
+  override def main(context: Context): DataStream[T] = {
     val config = Map("database" -> database,
                      "collection" -> collection,
                      "server" -> server)
 
     val bsonDocument = query.underlyingDocument
 
-    pipeline.environment.addSource(new BaseMongoSource[T](config, bsonDocument))
+    context.env.addSource(new BaseMongoSource[T](config, bsonDocument))
   }
 }

--- a/codefeedr-plugins/codefeedr-rabbitmq/src/main/scala/org/codefeedr/plugins/rabbitmq/stages/RabbitMQInput.scala
+++ b/codefeedr-plugins/codefeedr-rabbitmq/src/main/scala/org/codefeedr/plugins/rabbitmq/stages/RabbitMQInput.scala
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.streaming.connectors.rabbitmq.RMQSource
 import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig
 import org.codefeedr.buffer.serialization.{AbstractSerde, Serializer}
+import org.codefeedr.pipeline.Context
 import org.codefeedr.stages.InputStage
 
 import scala.reflect.{ClassTag, classTag}
@@ -49,7 +50,7 @@ class RabbitMQInput[T <: Serializable with AnyRef: ClassTag: TypeTag](
   implicit val typeInfo = TypeInformation.of(inputClassType)
 
   /** Add the InputSource to the Flink environment. */
-  override def main(): DataStream[T] = {
+  override def main(context: Context): DataStream[T] = {
     val config = new RMQConnectionConfig.Builder()
       .setUri(server.toString)
       .build
@@ -57,7 +58,7 @@ class RabbitMQInput[T <: Serializable with AnyRef: ClassTag: TypeTag](
     // Create a source with correlation id usage enabled for exactly once guarantees
     val source = new RMQSource[T](config, queue, true, getSerializer)
 
-    pipeline.environment
+    context.env
       .addSource(source)
       .setParallelism(1) // Needed for exactly one guarantees
   }

--- a/codefeedr-plugins/codefeedr-rss/src/main/scala/org/codefeedr/plugins/rss/stages/RSSInput.scala
+++ b/codefeedr-plugins/codefeedr-rss/src/main/scala/org/codefeedr/plugins/rss/stages/RSSInput.scala
@@ -19,6 +19,7 @@
 package org.codefeedr.plugins.rss.stages
 
 import org.apache.flink.streaming.api.scala.{DataStream, _}
+import org.codefeedr.pipeline.Context
 import org.codefeedr.plugins.rss.{RSSItem, RSSSource}
 import org.codefeedr.stages.InputStage
 
@@ -28,9 +29,8 @@ class RSSInput(url: String,
                stageId: Option[String] = None)
     extends InputStage[RSSItem](stageId) {
 
-  override def main(): DataStream[RSSItem] = {
-    pipeline.environment.addSource(
-      new RSSSource(url, dateFormat, pollingInterval))
+  override def main(context: Context): DataStream[RSSItem] = {
+    context.env.addSource(new RSSSource(url, dateFormat, pollingInterval))
   }
 
 }

--- a/codefeedr-plugins/codefeedr-travis/src/main/scala/org/codefeedr/plugins/travis/stages/TravisFilterActiveReposTransformStage.scala
+++ b/codefeedr-plugins/codefeedr-travis/src/main/scala/org/codefeedr/plugins/travis/stages/TravisFilterActiveReposTransformStage.scala
@@ -31,7 +31,8 @@ import org.codefeedr.stages.TransformStage
 class TravisFilterActiveReposTransformStage()
     extends TransformStage[PushEvent, PushEventFromActiveTravisRepo] {
 
-  lazy val travisService: TravisService = new TravisService(pipeline.keyManager)
+  lazy val travisService: TravisService = new TravisService(
+    getContext.pipeline.keyManager)
   def travis: TravisService = travisService
 
   override def transform(source: DataStream[PushEvent])

--- a/codefeedr-plugins/codefeedr-travis/src/main/scala/org/codefeedr/plugins/travis/stages/TravisPushEventBuildInfoTransformStage.scala
+++ b/codefeedr-plugins/codefeedr-travis/src/main/scala/org/codefeedr/plugins/travis/stages/TravisPushEventBuildInfoTransformStage.scala
@@ -42,7 +42,8 @@ import scala.util.{Failure, Success}
 class TravisPushEventBuildInfoTransformStage(capacity: Int = 100)
     extends TransformStage[PushEventFromActiveTravisRepo, TravisBuild] {
 
-  lazy val travisService: TravisService = new TravisService(pipeline.keyManager)
+  lazy val travisService: TravisService = new TravisService(
+    getContext.pipeline.keyManager)
   def travis: TravisService = travisService
 
   def transform(source: DataStream[PushEventFromActiveTravisRepo])

--- a/codefeedr-plugins/codefeedr-travis/src/test/scala/org/codefeedr/plugins/travis/stages/TravisFilterActiveReposTransformStageTest.scala
+++ b/codefeedr-plugins/codefeedr-travis/src/test/scala/org/codefeedr/plugins/travis/stages/TravisFilterActiveReposTransformStageTest.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.scala.DataStream
 import org.codefeedr.keymanager.StaticKeyManager
-import org.codefeedr.pipeline.PipelineBuilder
+import org.codefeedr.pipeline.{Context, PipelineBuilder}
 import org.codefeedr.plugins.github.GitHubProtocol.Event
 import org.codefeedr.plugins.github.requests.EventService
 import org.codefeedr.plugins.github.stages.GitHubEventToPushEvent
@@ -85,10 +85,10 @@ class SimpleEventSource(fileName: String) extends InputStage[Event] {
   val stream: InputStream = getClass.getResourceAsStream(fileName)
   val sampleEvents: String = Source.fromInputStream(stream).getLines.mkString
 
-  override def main(): DataStream[Event] = {
+  override def main(context: Context): DataStream[Event] = {
     val events = new EventService(false, null)
       .parseEvents(sampleEvents)
 
-    pipeline.environment.fromCollection(events)
+    context.env.fromCollection(events)
   }
 }

--- a/codefeedr-plugins/codefeedr-twitter/src/main/scala/org/codefeedr/plugin/twitter/stages/TwitterStatusInput.scala
+++ b/codefeedr-plugins/codefeedr-twitter/src/main/scala/org/codefeedr/plugin/twitter/stages/TwitterStatusInput.scala
@@ -36,8 +36,10 @@ import org.apache.flink.streaming.api.functions.source.{
   SourceFunction
 }
 import org.apache.flink.streaming.api.scala.DataStream
+import org.codefeedr.pipeline.Context
 import org.codefeedr.plugin.twitter.TwitterProtocol.TweetWrapper
 import org.codefeedr.stages.InputStage
+
 import scala.concurrent.blocking
 
 /**
@@ -63,8 +65,8 @@ class TwitterStatusInput(consumerToken: ConsumerToken,
                          stageId: Option[String] = None)
     extends InputStage[TweetWrapper](stageId) {
 
-  def main(): DataStream[TweetWrapper] = {
-    environment.addSource(
+  def main(context: Context): DataStream[TweetWrapper] = {
+    context.env.addSource(
       new TwitterStatusSource(consumerToken,
                               accessToken,
                               follow,

--- a/codefeedr-plugins/codefeedr-twitter/src/main/scala/org/codefeedr/plugin/twitter/stages/TwitterTrendingStatusInput.scala
+++ b/codefeedr-plugins/codefeedr-twitter/src/main/scala/org/codefeedr/plugin/twitter/stages/TwitterTrendingStatusInput.scala
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.api.scala.DataStream
 import org.codefeedr.plugin.twitter.TwitterProtocol.TweetWrapper
 import org.codefeedr.stages.InputStage
 import org.apache.flink.api.scala._
+import org.codefeedr.pipeline.Context
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
@@ -53,8 +54,8 @@ class TwitterTrendingStatusInput(consumerToken: ConsumerToken,
                                  stageId: Option[String] = None)
     extends InputStage[TweetWrapper](stageId) {
 
-  override def main(): DataStream[TweetWrapper] = {
-    environment.addSource(
+  override def main(context: Context): DataStream[TweetWrapper] = {
+    context.env.addSource(
       new TwitterTrendingStatusSource(consumerToken, accessToken, sleepTime))
   }
 }

--- a/codefeedr-plugins/codefeedr-twitter/src/test/scala/org/codefeedr/plugin/twitter/stages/TwitterStatusInputTest.scala
+++ b/codefeedr-plugins/codefeedr-twitter/src/test/scala/org/codefeedr/plugin/twitter/stages/TwitterStatusInputTest.scala
@@ -48,6 +48,7 @@ import org.mockito.Mockito._
 import org.mockito.Matchers._
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
+import org.codefeedr.pipeline.Context
 import org.mockito.exceptions.verification.NoInteractionsWanted
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -133,14 +134,15 @@ class TwitterStatusInputTest extends FunSuite with MockitoSugar {
 
   test("A source needs to be properly added to the environment") {
     val env = mock[StreamExecutionEnvironment]
+    val context = Context(env, "", null, null)
     val stage = spy(new TwitterStatusInput(consumerToken, accessToken))
 
-    doReturn(env)
+    doReturn(context)
       .when(stage)
-      .environment
+      .getContext
 
     stage
-      .main()
+      .main(context)
 
     //for some reason this doesn't work, gives exception: 2 matches expected, 1 recorded
     // verify(env, times(1)).addSource(any[SourceFunction[TweetWrapper]])

--- a/codefeedr-plugins/codefeedr-twitter/src/test/scala/org/codefeedr/plugin/twitter/stages/TwitterTrendingStatusInputTest.scala
+++ b/codefeedr-plugins/codefeedr-twitter/src/test/scala/org/codefeedr/plugin/twitter/stages/TwitterTrendingStatusInputTest.scala
@@ -37,6 +37,7 @@ import com.danielasfregola.twitter4s.http.clients.streaming.TwitterStream
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.codefeedr.pipeline.Context
 import org.codefeedr.plugin.twitter.TwitterProtocol.TweetWrapper
 import org.mockito.{ArgumentCaptor, Matchers}
 import org.mockito.Matchers.any
@@ -191,14 +192,15 @@ class TwitterTrendingStatusInputTest extends FunSuite with MockitoSugar {
 
   test("A source needs to be properly added to the environment") {
     val env = mock[StreamExecutionEnvironment]
+    val context = Context(env, "", null, null)
     val stage = spy(new TwitterTrendingStatusInput(consumerToken, accessToken))
 
-    doReturn(env)
+    doReturn(context)
       .when(stage)
-      .environment
+      .getContext
 
     stage
-      .main()
+      .main(context)
 
     //for some reason this doesn't work, gives exception: 2 matches expected, 1 recorded
     // verify(env, times(1)).addSource(any[SourceFunction[TweetWrapper]])

--- a/codefeedr-plugins/codefeedr-weblogs/src/main/scala/org/codefeedr/plugins/weblogs/stages/HttpdLogInput.scala
+++ b/codefeedr-plugins/codefeedr-weblogs/src/main/scala/org/codefeedr/plugins/weblogs/stages/HttpdLogInput.scala
@@ -19,9 +19,11 @@
 package org.codefeedr.plugins.weblogs.stages
 
 import java.text.SimpleDateFormat
+
 import org.apache.flink.api.common.functions.FlatMapFunction
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.util.Collector
+import org.codefeedr.pipeline.Context
 import org.codefeedr.plugins.weblogs.HttpdLogItem
 import org.codefeedr.stages.InputStage
 
@@ -34,8 +36,8 @@ class HttpdLogInput(absolutePath: String, stageId: Option[String] = None)
     extends InputStage[HttpdLogItem](stageId)
     with Serializable {
 
-  override def main(): DataStream[HttpdLogItem] = {
-    pipeline.environment
+  override def main(context: Context): DataStream[HttpdLogItem] = {
+    context.env
       .readTextFile(absolutePath)
       .setParallelism(1)
       .flatMap(_.split('\n'))

--- a/codefeedr-plugins/codefeedr-weblogs/src/test/scala/org/codefeedr/plugins/weblogs/testUtils/PipelineObjects.scala
+++ b/codefeedr-plugins/codefeedr-weblogs/src/test/scala/org/codefeedr/plugins/weblogs/testUtils/PipelineObjects.scala
@@ -44,7 +44,7 @@ class SimpleSourceStage(stageId: Option[String] = None)
     extends Stage[Nothing, StringType](stageId) {
   override def transform(
       source: DataStream[Nothing]): DataStream[StringType] = {
-    pipeline.environment.addSource {
+    getContext.env.addSource {
       new RichSourceFunction[StringType] {
         override def run(
             ctx: SourceFunction.SourceContext[StringType]): Unit = {
@@ -97,7 +97,7 @@ class HitObjectTest extends Stage[Nothing, Nothing] {
 class FlinkCrashObjectTest extends Stage[Nothing, StringType] {
   override def transform(
       source: DataStream[Nothing]): DataStream[StringType] = {
-    pipeline.environment
+    getContext.env
       .fromCollection[String](Seq("a", "b"))
       .map { a =>
         throw CodeHitException()


### PR DESCRIPTION
Related issue(s): #176 
### Description of changes
Instead of accessing `stage.properties`, `stage.env` directly it now needs to be retrieved through `stage.getContext.env`. Besides the `main` method in `InputStage` is directly instantiated with this Context.

### Check-list

_Please make sure to review and check all of these items:_

- [x] Are the updated classes tested?
- [x] Are the updated classes documented & properly formatted?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._
