### PR TITLE
Kafka offsets

### DIFF
--- a/codefeedr-core/src/main/scala/org/codefeedr/Properties.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/Properties.scala
@@ -87,6 +87,11 @@ class Properties(private val contents: Map[String, String] = Map()) {
   def set[T](key: String, value: T)(implicit convert: T => String): Properties =
     new Properties(contents + (key -> value))
 
+  /** Merges two Properties object.
+    *
+    * @param properties the second properties object. These properties will override the keys of *this*.
+    * @return new properties.
+    */
   def merge(properties: Properties): Properties = {
     val keys = properties.keys()
     var newProps = this

--- a/codefeedr-core/src/main/scala/org/codefeedr/Properties.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/Properties.scala
@@ -26,6 +26,10 @@ object Properties {
   // Conversion implicits
   implicit def stringToBoolean(str: String): Boolean = str.toBoolean
   implicit def booleanToString(bool: Boolean): String = bool.toString
+
+  // Conversion implicits
+  implicit def longToString(lng: Long): String = lng.toString
+  implicit def stringToLong(str: String): Long = str.toLong
 }
 
 /** Object containing configuration properties. */

--- a/codefeedr-core/src/main/scala/org/codefeedr/Properties.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/Properties.scala
@@ -87,6 +87,17 @@ class Properties(private val contents: Map[String, String] = Map()) {
   def set[T](key: String, value: T)(implicit convert: T => String): Properties =
     new Properties(contents + (key -> value))
 
+  def merge(properties: Properties): Properties = {
+    val keys = properties.keys()
+    var newProps = this
+
+    for (key <- keys) {
+      newProps = newProps.set(key, properties.get(key).get)
+    }
+
+    newProps
+  }
+
   /**
     * Get a set if keys in this properties.
     *

--- a/codefeedr-core/src/main/scala/org/codefeedr/Properties.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/Properties.scala
@@ -26,10 +26,6 @@ object Properties {
   // Conversion implicits
   implicit def stringToBoolean(str: String): Boolean = str.toBoolean
   implicit def booleanToString(bool: Boolean): String = bool.toString
-
-  // Conversion implicits
-  implicit def longToString(lng: Long): String = lng.toString
-  implicit def stringToLong(str: String): Long = str.toLong
 }
 
 /** Object containing configuration properties. */

--- a/codefeedr-core/src/main/scala/org/codefeedr/buffer/Buffer.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/buffer/Buffer.scala
@@ -70,6 +70,9 @@ abstract class Buffer[T <: Serializable with AnyRef: ClassTag: TypeTag](
 
     Serializer.getSerde[T](serializer)
   }
+
+  /** Returns the properties of this buffer. */
+  def getProperties = properties
 }
 
 /**

--- a/codefeedr-core/src/main/scala/org/codefeedr/buffer/BufferFactory.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/buffer/BufferFactory.scala
@@ -65,10 +65,11 @@ class BufferFactory[+In <: Serializable with AnyRef,
     pipeline.bufferType match {
       case BufferType.Kafka => {
         val cleanedSubject = subject.replace("$", "-")
-        new KafkaBuffer[T](pipeline,
-                           pipeline.bufferProperties,
-                           cleanedSubject,
-                           groupIdFinal)
+        new KafkaBuffer[T](
+          pipeline,
+          stage.getContext.stageProperties.merge(pipeline.bufferProperties),
+          cleanedSubject,
+          groupIdFinal)
       }
       case x if BufferFactory.registry.exists(_._1 == x) => {
         val tt = typeTag[T]
@@ -80,16 +81,22 @@ class BufferFactory[+In <: Serializable with AnyRef,
           .get
           .runtimeClass
           .getConstructors()(0)
-          .newInstance(pipeline, pipeline.bufferProperties, subject, ct, tt)
+          .newInstance(
+            pipeline,
+            stage.getContext.stageProperties.merge(pipeline.bufferProperties),
+            subject,
+            ct,
+            tt)
           .asInstanceOf[Buffer[T]]
       }
       case _ => {
         //Switch to Kafka.
         val cleanedSubject = subject.replace("$", "-")
-        new KafkaBuffer[T](pipeline,
-                           pipeline.bufferProperties,
-                           cleanedSubject,
-                           groupIdFinal)
+        new KafkaBuffer[T](
+          pipeline,
+          stage.getContext.stageProperties.merge(pipeline.bufferProperties),
+          cleanedSubject,
+          groupIdFinal)
       }
     }
   }

--- a/codefeedr-core/src/main/scala/org/codefeedr/buffer/BufferFactory.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/buffer/BufferFactory.scala
@@ -67,7 +67,7 @@ class BufferFactory[+In <: Serializable with AnyRef,
         val cleanedSubject = subject.replace("$", "-")
         new KafkaBuffer[T](
           pipeline,
-          stage.getContext.stageProperties.merge(pipeline.bufferProperties),
+          pipeline.bufferProperties.merge(stage.getContext.stageProperties),
           cleanedSubject,
           groupIdFinal)
       }
@@ -83,7 +83,7 @@ class BufferFactory[+In <: Serializable with AnyRef,
           .getConstructors()(0)
           .newInstance(
             pipeline,
-            stage.getContext.stageProperties.merge(pipeline.bufferProperties),
+            pipeline.bufferProperties.merge(stage.getContext.stageProperties),
             subject,
             ct,
             tt)
@@ -94,7 +94,7 @@ class BufferFactory[+In <: Serializable with AnyRef,
         val cleanedSubject = subject.replace("$", "-")
         new KafkaBuffer[T](
           pipeline,
-          stage.getContext.stageProperties.merge(pipeline.bufferProperties),
+          pipeline.bufferProperties.merge(stage.getContext.stageProperties),
           cleanedSubject,
           groupIdFinal)
       }

--- a/codefeedr-core/src/main/scala/org/codefeedr/buffer/KafkaBuffer.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/buffer/KafkaBuffer.scala
@@ -59,6 +59,14 @@ object KafkaBuffer {
   val AMOUNT_OF_REPLICAS = "AMOUNT_OF_REPLICAS"
   val COMPRESSION_TYPE = "compression.type"
 
+  //OFFSETS
+  val START_POSITION = "START_POSITION"
+  val START_TIMESTAMP = "START_TIMESTAMP"
+  val GROUP_OFFSETS = "GROUP_OFFSETS"
+  val TIMESTAMP = "TIMESTAMP"
+  val LATEST = "LATEST"
+  val EARLIEST = "EARLIEST"
+
 }
 
 /** The implementation for the Kafka buffer. This buffer is the default.
@@ -96,6 +104,10 @@ class KafkaBuffer[T <: Serializable with AnyRef: ClassTag: TypeTag](
     val AMOUNT_OF_PARTITIONS = 1
     val AMOUNT_OF_REPLICAS = 1
     val COMPRESSION_TYPE = "none"
+
+    //OFFSETS
+    val START_POSITION = "group_offsets"
+    val START_TIMESTAMP = "START_TIMESTAMP"
   }
 
   /** Get a Kafka Consumer as source for a stage.

--- a/codefeedr-core/src/main/scala/org/codefeedr/buffer/KafkaBuffer.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/buffer/KafkaBuffer.scala
@@ -106,7 +106,7 @@ class KafkaBuffer[T <: Serializable with AnyRef: ClassTag: TypeTag](
     val COMPRESSION_TYPE = "none"
 
     //OFFSETS
-    val START_POSITION = "group_offsets"
+    val START_POSITION = KafkaBuffer.GROUP_OFFSETS
     val START_TIMESTAMP = 0x0
   }
 

--- a/codefeedr-core/src/main/scala/org/codefeedr/buffer/KafkaBuffer.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/buffer/KafkaBuffer.scala
@@ -129,21 +129,21 @@ class KafkaBuffer[T <: Serializable with AnyRef: ClassTag: TypeTag](
       KafkaBuffer.START_POSITION,
       KafkaBufferDefaults.START_POSITION)
 
-    /** Configure the starting point. */
+    /** Configure the starting point FromGroupOffsets. */
     startPosition match {
       case KafkaBuffer.EARLIEST => kafkaConsumer.setStartFromEarliest()
       case KafkaBuffer.LATEST   => kafkaConsumer.setStartFromLatest()
       case KafkaBuffer.TIMESTAMP =>
         kafkaConsumer.setStartFromTimestamp(
-          properties.getOrElse[Long](KafkaBuffer.START_POSITION,
-                                     KafkaBufferDefaults.START_TIMESTAMP))
+          properties.getOrElse[Long](
+            KafkaBuffer.START_POSITION,
+            KafkaBufferDefaults.START_TIMESTAMP)(_.toLong))
       case KafkaBuffer.GROUP_OFFSETS => kafkaConsumer.setStartFromGroupOffsets()
       case _                         => kafkaConsumer.setStartFromGroupOffsets()
     }
 
     // Add a source.
-    pipeline.environment.addSource(
-      new FlinkKafkaConsumer[T](topic, serde, getKafkaProperties))
+    pipeline.environment.addSource(kafkaConsumer)
   }
 
   /** Get a Kafka Producer as sink to the buffer.

--- a/codefeedr-core/src/main/scala/org/codefeedr/buffer/KafkaBuffer.scala
+++ b/codefeedr-core/src/main/scala/org/codefeedr/buffer/KafkaBuffer.scala
@@ -136,7 +136,7 @@ class KafkaBuffer[T <: Serializable with AnyRef: ClassTag: TypeTag](
       case KafkaBuffer.TIMESTAMP =>
         kafkaConsumer.setStartFromTimestamp(
           properties.getOrElse[Long](
-            KafkaBuffer.START_POSITION,
+            KafkaBuffer.START_TIMESTAMP,
             KafkaBufferDefaults.START_TIMESTAMP)(_.toLong))
       case KafkaBuffer.GROUP_OFFSETS => kafkaConsumer.setStartFromGroupOffsets()
       case _                         => kafkaConsumer.setStartFromGroupOffsets()

--- a/codefeedr-core/src/test/scala/org/codefeedr/PropertiesTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/PropertiesTest.scala
@@ -125,4 +125,17 @@ class PropertiesTest extends FunSuite {
     assert(props.has("foo"))
     assert(!props.has("bar"))
   }
+
+  test("Two property maps should be able to merge") {
+    var props = new Properties()
+    var props2 = new Properties()
+
+    props = props.set("ha", "na")
+    props2 = props2.set("bla", "na")
+
+    val finalProps = props.merge(props2)
+
+    assert(finalProps.has("ha"))
+    assert(finalProps.has("bla"))
+  }
 }

--- a/codefeedr-core/src/test/scala/org/codefeedr/PropertiesTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/PropertiesTest.scala
@@ -138,4 +138,18 @@ class PropertiesTest extends FunSuite {
     assert(finalProps.has("ha"))
     assert(finalProps.has("bla"))
   }
+
+  test("Two property maps should be able to merge and overridden") {
+    var props = new Properties()
+    var props2 = new Properties()
+
+    props = props.set("ha", "na")
+    props2 = props2.set("ha", "ba")
+
+    val finalProps = props.merge(props2)
+
+    assert(finalProps.has("ha"))
+    assert(!finalProps.has("bla"))
+    assert(finalProps.get("ha").get.equals("ba"))
+  }
 }

--- a/codefeedr-core/src/test/scala/org/codefeedr/buffer/KafkaBufferTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/buffer/KafkaBufferTest.scala
@@ -76,6 +76,7 @@ class KafkaBufferTest
 
     //setup simple kafkabuffer
     val pipeline = new PipelineBuilder()
+      .setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.LATEST)
       .append(new SimpleSourceStage())
       .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE_HOST,
                          s"redis://localhost:$redisPort")
@@ -118,6 +119,7 @@ class KafkaBufferTest
     val numberInput = new NumberInput()
 
     val pipeline = new PipelineBuilder()
+      .setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.EARLIEST)
       .append(numberInput) //pushes 1 till 50
       .append(numberOutput) //reads and crashes
       .build()

--- a/codefeedr-core/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
@@ -217,6 +217,8 @@ class PipelineTest
       .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE, "true")
       .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE_SERVICE, "zookeeper")
       .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE_HOST, "localhost:2181")
+      .setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.TIMESTAMP)
+      .setBufferProperty(KafkaBuffer.START_TIMESTAMP, "0x0")
       .build()
 
     assertThrows[JobExecutionException] {

--- a/codefeedr-core/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
+++ b/codefeedr-core/src/test/scala/org/codefeedr/pipeline/PipelineTest.scala
@@ -218,7 +218,7 @@ class PipelineTest
       .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE_SERVICE, "zookeeper")
       .setBufferProperty(KafkaBuffer.SCHEMA_EXPOSURE_HOST, "localhost:2181")
       .setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.TIMESTAMP)
-      .setBufferProperty(KafkaBuffer.START_TIMESTAMP, "0x0")
+      .setBufferProperty(KafkaBuffer.START_TIMESTAMP, "0")
       .build()
 
     assertThrows[JobExecutionException] {

--- a/docs/pages/mydoc/mydoc_buffer.md
+++ b/docs/pages/mydoc/mydoc_buffer.md
@@ -51,6 +51,14 @@ To set the start position for **all** stages in a pipeline it can be configured 
 - Earliest: `setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.EARLIEST)`
 - Timestamp: `setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.TIMESTAMP)` and `setBufferProperty(KafkaBuffer.START_TIMESTAMP, "START_TIMESTAMP_HERE")`
 
+To set the start position on **stage** level, you need to use stage properties:
+- Group offsets (default): `setStageProperty(stageInstance, KafkaBuffer.START_POSITION, KafkaBuffer.GROUP_OFFSETS)`
+- Latest: `setStageProperty(stageInstance, KafkaBuffer.START_POSITION, KafkaBuffer.LATEST)`
+- Earliest: `setStageProperty(stageInstance, KafkaBuffer.START_POSITION, KafkaBuffer.EARLIEST)`
+- Timestamp: `setStageProperty(stageInstance, KafkaBuffer.START_POSITION, KafkaBuffer.TIMESTAMP)` and `setBufferProperty(KafkaBuffer.START_TIMESTAMP, "START_TIMESTAMP_HERE")`
+
+This will set the start position of the Kafka consumer of the `stageInstance`. I.e. if set to `LATEST`, `stageInstance` will start consuming from the latest entry of the stage it is linked to. 
+
 ### Default properties
 
 #### Kafka

--- a/docs/pages/mydoc/mydoc_buffer.md
+++ b/docs/pages/mydoc/mydoc_buffer.md
@@ -36,6 +36,8 @@ pipelineBuilder
     .setBufferProperty(KafkaBuffer.BROKER, "localhost:9092")
 ```
 
+To set buffer properties on _stage level_ use stage properties `.setStageProperty(stageInstance, key, value)`. This will override a global buffer property. 
+
 **Note:** in case of the Kafka buffer all these properties will be
 propagated to the Kafka producer/consumer, see the [Kafka
 documentation](https://kafka.apache.org/documentation/#configuration)

--- a/docs/pages/mydoc/mydoc_buffer.md
+++ b/docs/pages/mydoc/mydoc_buffer.md
@@ -40,6 +40,15 @@ pipelineBuilder
 propagated to the Kafka producer/consumer, see the [Kafka
 documentation](https://kafka.apache.org/documentation/#configuration)
 for specifics.
+
+### Kafka Start position
+To set the start position for **all** stages in a pipeline it can be configured as buffer property:
+
+- Group offsets (default): `setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.GROUP_OFFSETS)`
+- Latest: `setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.LATEST)`
+- Earliest: `setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.EARLIEST)`
+- Timestamp: `setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.TIMESTAMP)` and `setBufferProperty(KafkaBuffer.START_TIMESTAMP, "START_TIMESTAMP_HERE")`
+
 ### Default properties
 
 #### Kafka

--- a/docs/pages/mydoc/mydoc_pipeline.md
+++ b/docs/pages/mydoc/mydoc_pipeline.md
@@ -204,7 +204,7 @@ getContext.getStageProperties("the_key")
 This will return `Some("the_value")`, if the key is unknown `None` will
 be returned.
 
-**Note**: Stage properties are also added to the _buffer properties_ of the buffer belonging to that stage. So to override buffer properties on __stage level__, use stage properties.  
+**Note**: Stage properties are also added to the _buffer properties_ of the buffer belonging to that stage. So to override buffer properties on _stage level_, use stage properties.  
 
 ### Start the pipeline
 If the Pipeline is properly build using the PipelineBuilder, it can be

--- a/docs/pages/mydoc/mydoc_pipeline.md
+++ b/docs/pages/mydoc/mydoc_pipeline.md
@@ -204,6 +204,8 @@ getContext.getStageProperties("the_key")
 This will return `Some("the_value")`, if the key is unknown `None` will
 be returned.
 
+**Note**: Stage properties are also added to the _buffer properties_ of the buffer belonging to that stage. So to override buffer properties on __stage level__, use stage properties.  
+
 ### Start the pipeline
 If the Pipeline is properly build using the PipelineBuilder, it can be
 started in three modes:


### PR DESCRIPTION
Related issue(s): <!-- Link the related issues here -->
### Description of changes
Set Kafka start offsets on both stage and pipeline level.

Example:

```scala
new PipelineBuilder()
    .setBufferProperty(KafkaBuffer.START_POSITION, KafkaBuffer.LATEST)
    .edge(a, b)
    .edge(b, c)
    .setStageProperty(b, KafkaBuffer.START_POSITION, KafkaBuffer.EARLIEST)
    .build()
```
In this setup `c` reads from `b` from the `LATEST` offset while `b` reads from `a` from the `EARLIEST` offset.

### Check-list

_Please make sure to review and check all of these items:_

- [x] Are the updated classes tested?
- [x] Are the updated classes documented & properly formatted?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._
